### PR TITLE
Host cube image on devdownloads

### DIFF
--- a/even-easier-cuda/An_Even_Easier_Introduction_to_CUDA.ipynb
+++ b/even-easier-cuda/An_Even_Easier_Introduction_to_CUDA.ipynb
@@ -49,7 +49,7 @@
         "id": "V1C6GK_MO5er"
       },
       "source": [
-        "<img src=\"https://developer-blogs.nvidia.com/wp-content/uploads/2012/10/CUDA_Cube_1K.jpg\" width=\"400\">"
+        "<img src=\"https://developer.download.nvidia.com/training/courses/T-AC-01-V1/CUDA_Cube_1K.jpeg\" width=\"400\">"
       ]
     },
     {


### PR DESCRIPTION
This PR moves the cube image off the blog CDN.