### PR TITLE
Update BuildingABrain.ipynb

### DIFF
--- a/building-a-brain/BuildingABrain.ipynb
+++ b/building-a-brain/BuildingABrain.ipynb
@@ -350,7 +350,7 @@
         "image_height = 28\n",
         "image_width = 28\n",
         "\n",
-        "number_of_weights = image_height * image_width * number_of_classes\n",
+        "number_of_weights = image_height * image_width * int(number_of_classes)\n",
         "number_of_weights"
       ],
       "execution_count": null,


### PR DESCRIPTION
number_of_classes is a NumPy unsigned 8-bit integer (np.uint8). If multiplied by integer variable generates a compile time error. Fixed by casting the data type to int.